### PR TITLE
feat: set Cache-Control to 1 year

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,11 +1,21 @@
+// env
 const isDevelopment = process.env.NODE_ENV === 'development';
+
+// response headers
 const contentType = 'Content-Type';
 const imageSvgXml = 'image/svg+xml';
+
+const cacheControl = 'Cache-Control';
+const cacheOneYear = 'public, max-age=31557600';
+
+// svg
 const emptySvg = '<svg xmlns="http://www.w3.org/2000/svg"/>';
 
 const constants = {
   isDevelopment,
   contentType,
+  cacheControl,
+  cacheOneYear,
   imageSvgXml,
   emptySvg,
 };

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -6,7 +6,7 @@ const contentType = 'Content-Type';
 const imageSvgXml = 'image/svg+xml';
 
 const cacheControl = 'Cache-Control';
-const cacheOneYear = 'public, max-age=31557600';
+const cacheOneYear = 'public,max-age=31557600,immutable';
 
 // svg
 const emptySvg = '<svg xmlns="http://www.w3.org/2000/svg"/>';

--- a/helpers/express.js
+++ b/helpers/express.js
@@ -1,4 +1,9 @@
-const { contentType, imageSvgXml } = require('./constants');
+const {
+  contentType,
+  imageSvgXml,
+  cacheControl,
+  cacheOneYear,
+} = require('./constants');
 
 /**
  * Sends SVG as response.
@@ -7,7 +12,8 @@ const { contentType, imageSvgXml } = require('./constants');
  * @param {String} svg
  */
 const sendSvg = (res, svg) => {
-  res.setHeader(contentType, imageSvgXml);
+  res.set(contentType, imageSvgXml);
+  res.set(cacheControl, cacheOneYear);
   res.send(svg);
 };
 

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "texsvg": "^1.3.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^8.3.5",
-    "@commitlint/config-conventional": "^8.3.4",
+    "@commitlint/cli": "^9.0.1",
+    "@commitlint/config-conventional": "^9.0.1",
     "husky": "^4.2.5",
-    "jest": "^25.5.4",
+    "jest": "^26.1.0",
     "nodemon": "^2.0.3",
-    "standard-version": "^7.1.0",
+    "standard-version": "^8.0.0",
     "supertest": "^4.0.2"
   },
   "engines": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -47,6 +47,7 @@ router.use((req, res, next) => {
  * Error
  */
 router.use((err, req, res, next) => {
+  /* istanbul ignore next */
   if (isDevelopment) {
     return next(err);
   }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,6 +1,12 @@
 const supertest = require('supertest');
 const app = require('../app');
-let { contentType, imageSvgXml, emptySvg } = require('../helpers/constants');
+let {
+  contentType,
+  imageSvgXml,
+  cacheControl,
+  cacheOneYear,
+  emptySvg,
+} = require('../helpers/constants');
 const svgs = require('../helpers/svgs');
 
 imageSvgXml += '; charset=utf-8';
@@ -33,6 +39,7 @@ describe('GET /', () => {
     await agent
       .get('/')
       .expect(contentType, imageSvgXml)
+      .expect(cacheControl, cacheOneYear)
       .expect(status200)
       .expect(res => {
         expect(res.body.toString()).toBe(emptySvg);
@@ -52,6 +59,7 @@ describe(`GET /?tex=${tex1}`, () => {
     await agent
       .get(`/?tex=${tex1}`)
       .expect(contentType, imageSvgXml)
+      .expect(cacheControl, cacheOneYear)
       .expect(status200)
       .expect(res => {
         svg = res.body.toString();
@@ -77,6 +85,7 @@ describe(`GET /?tex=${tex2}`, () => {
     await agent
       .get(`/?tex=${tex2}`)
       .expect(contentType, imageSvgXml)
+      .expect(cacheControl, cacheOneYear)
       .expect(status200)
       .expect(res => {
         svg = res.body.toString();
@@ -102,6 +111,7 @@ describe(`GET /?tex=${tex3}`, () => {
     await agent
       .get(`/?tex=${tex3}`)
       .expect(contentType, imageSvgXml)
+      .expect(cacheControl, cacheOneYear)
       .expect(status200)
       .expect(res => {
         svg = res.body.toString();


### PR DESCRIPTION
## What is the motivation for this pull request?

feature: set `Cache-Control` to 1 year

## What is the current behavior?

No `Cache-Control` header so SVG's are not getting cached

## What is the new behavior?

New response header:

```
Cache-Control: public,max-age=31536000,immutable
```

This allows for `304 Not Modified` to be returned if a visited URL is refreshed.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Caching_static_assets

## Checklist:

- [x] Tests